### PR TITLE
Add maintenance module and navigation entry point

### DIFF
--- a/app/src/main/java/com/joel/mycar/core/data/AppDatabase.kt
+++ b/app/src/main/java/com/joel/mycar/core/data/AppDatabase.kt
@@ -6,16 +6,20 @@ import com.joel.mycar.feature.fuel.data.MonthlyStatDao
 import com.joel.mycar.feature.fuel.data.RefuelDao
 import com.joel.mycar.feature.fuel.domain.MonthlyStat
 import com.joel.mycar.feature.fuel.domain.Refuel
+import com.joel.mycar.feature.maintenance.data.MaintenanceTaskDao
+import com.joel.mycar.feature.maintenance.domain.MaintenanceTask
 
 @Database(
     entities = [
         Refuel::class,
-        MonthlyStat::class
+        MonthlyStat::class,
+        MaintenanceTask::class
     ],
-    version = 3,
+    version = 4,
     exportSchema = true
 )
 abstract class AppDatabase : RoomDatabase() {
     abstract fun refuelDao(): RefuelDao
     abstract fun monthlyStatDao(): MonthlyStatDao
+    abstract fun maintenanceTaskDao(): MaintenanceTaskDao
 }

--- a/app/src/main/java/com/joel/mycar/core/di/ServiceLocator.kt
+++ b/app/src/main/java/com/joel/mycar/core/di/ServiceLocator.kt
@@ -31,6 +31,26 @@ object ServiceLocator {
         }
     }
 
+    private val MIGRATION_3_4 = object : Migration(3, 4) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL(
+                """
+                CREATE TABLE IF NOT EXISTS maintenance_tasks(
+                    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                    title TEXT NOT NULL,
+                    details TEXT,
+                    dateEpochDay INTEGER NOT NULL,
+                    odometerKm REAL,
+                    cost REAL,
+                    materials TEXT,
+                    nextDueEpochDay INTEGER,
+                    nextDueOdometerKm REAL
+                )
+                """.trimIndent()
+            )
+        }
+    }
+
     fun database(context: Context): AppDatabase =
         db ?: synchronized(this) {
             db ?: Room.databaseBuilder(
@@ -38,7 +58,7 @@ object ServiceLocator {
                 AppDatabase::class.java,
                 "mycar.db"
             )
-                .addMigrations(MIGRATION_1_2, MIGRATION_2_3)
+                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4)
                 .build()
                 .also { db = it }
         }

--- a/app/src/main/java/com/joel/mycar/feature/maintenance/data/MaintenanceTaskDao.kt
+++ b/app/src/main/java/com/joel/mycar/feature/maintenance/data/MaintenanceTaskDao.kt
@@ -1,0 +1,20 @@
+package com.joel.mycar.feature.maintenance.data
+
+import androidx.room.*
+import com.joel.mycar.feature.maintenance.domain.MaintenanceTask
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface MaintenanceTaskDao {
+    @Query("SELECT * FROM maintenance_tasks ORDER BY dateEpochDay DESC")
+    fun observeAll(): Flow<List<MaintenanceTask>>
+
+    @Query("SELECT * FROM maintenance_tasks WHERE id = :id")
+    fun observeById(id: Long): Flow<MaintenanceTask?>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(task: MaintenanceTask)
+
+    @Delete
+    suspend fun delete(task: MaintenanceTask)
+}

--- a/app/src/main/java/com/joel/mycar/feature/maintenance/domain/MaintenanceRepository.kt
+++ b/app/src/main/java/com/joel/mycar/feature/maintenance/domain/MaintenanceRepository.kt
@@ -1,0 +1,18 @@
+package com.joel.mycar.feature.maintenance.domain
+
+import com.joel.mycar.feature.maintenance.data.MaintenanceTaskDao
+import kotlinx.coroutines.flow.Flow
+
+class MaintenanceRepository(private val dao: MaintenanceTaskDao) {
+    val tasks: Flow<List<MaintenanceTask>> = dao.observeAll()
+
+    fun task(id: Long): Flow<MaintenanceTask?> = dao.observeById(id)
+
+    suspend fun save(task: MaintenanceTask) {
+        dao.upsert(task)
+    }
+
+    suspend fun delete(task: MaintenanceTask) {
+        dao.delete(task)
+    }
+}

--- a/app/src/main/java/com/joel/mycar/feature/maintenance/domain/MaintenanceTask.kt
+++ b/app/src/main/java/com/joel/mycar/feature/maintenance/domain/MaintenanceTask.kt
@@ -1,0 +1,17 @@
+package com.joel.mycar.feature.maintenance.domain
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "maintenance_tasks")
+data class MaintenanceTask(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val title: String,
+    val details: String? = null,
+    val dateEpochDay: Long,
+    val odometerKm: Double? = null,
+    val cost: Double? = null,
+    val materials: String? = null,
+    val nextDueEpochDay: Long? = null,
+    val nextDueOdometerKm: Double? = null
+)

--- a/app/src/main/java/com/joel/mycar/feature/maintenance/ui/MaintenanceFormScreen.kt
+++ b/app/src/main/java/com/joel/mycar/feature/maintenance/ui/MaintenanceFormScreen.kt
@@ -1,0 +1,205 @@
+package com.joel.mycar.feature.maintenance.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.joel.mycar.feature.maintenance.domain.MaintenanceTask
+import java.time.LocalDate
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MaintenanceFormScreen(
+    viewModel: MaintenanceViewModel,
+    taskId: Long?,
+    onDone: () -> Unit
+) {
+    var form by remember { mutableStateOf(MaintenanceForm()) }
+
+    val taskFlow = remember(taskId) { taskId?.let { viewModel.taskFlow(it) } }
+    val existing = taskFlow?.collectAsState(initial = null)?.value
+
+    LaunchedEffect(existing?.id) {
+        if (existing != null) {
+            form = MaintenanceForm.from(existing)
+        } else if (taskId == null) {
+            form = MaintenanceForm()
+        }
+    }
+
+    val scroll = rememberScrollState()
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+            .verticalScroll(scroll),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        Text(
+            text = if (taskId == null) "Nuevo mantenimiento" else "Editar mantenimiento",
+            style = MaterialTheme.typography.titleLarge
+        )
+
+        OutlinedTextField(
+            value = form.title,
+            onValueChange = { form = form.copy(title = it) },
+            label = { Text("Tarea *") },
+            modifier = Modifier.fillMaxWidth(),
+            isError = form.title.isBlank(),
+            supportingText = { if (form.title.isBlank()) Text("Campo obligatorio") }
+        )
+
+        OutlinedTextField(
+            value = form.date,
+            onValueChange = { form = form.copy(date = it) },
+            label = { Text("Fecha (YYYY-MM-DD) *") },
+            modifier = Modifier.fillMaxWidth(),
+            isError = !form.dateValid,
+            supportingText = { if (!form.dateValid) Text("Formato de fecha inválido") }
+        )
+
+        OutlinedTextField(
+            value = form.odometerKm,
+            onValueChange = { form = form.copy(odometerKm = it) },
+            label = { Text("Odómetro (km)") },
+            modifier = Modifier.fillMaxWidth(),
+            isError = !form.odometerValid,
+            supportingText = { if (!form.odometerValid) Text("Número inválido") }
+        )
+
+        OutlinedTextField(
+            value = form.cost,
+            onValueChange = { form = form.copy(cost = it) },
+            label = { Text("Costo") },
+            modifier = Modifier.fillMaxWidth(),
+            isError = !form.costValid,
+            supportingText = { if (!form.costValid) Text("Número inválido") }
+        )
+
+        OutlinedTextField(
+            value = form.materials,
+            onValueChange = { form = form.copy(materials = it) },
+            label = { Text("Materiales utilizados") },
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        OutlinedTextField(
+            value = form.details,
+            onValueChange = { form = form.copy(details = it) },
+            label = { Text("Detalles / notas") },
+            modifier = Modifier.fillMaxWidth(),
+            minLines = 3
+        )
+
+        Text("Recordatorio próximo servicio", style = MaterialTheme.typography.titleMedium)
+
+        OutlinedTextField(
+            value = form.nextDate,
+            onValueChange = { form = form.copy(nextDate = it) },
+            label = { Text("Fecha objetivo (YYYY-MM-DD)") },
+            modifier = Modifier.fillMaxWidth(),
+            isError = !form.nextDateValid,
+            supportingText = { if (!form.nextDateValid) Text("Formato de fecha inválido") }
+        )
+
+        OutlinedTextField(
+            value = form.nextOdometer,
+            onValueChange = { form = form.copy(nextOdometer = it) },
+            label = { Text("Odómetro objetivo (km)") },
+            modifier = Modifier.fillMaxWidth(),
+            isError = !form.nextOdometerValid,
+            supportingText = { if (!form.nextOdometerValid) Text("Número inválido") }
+        )
+
+        Spacer(Modifier.height(8.dp))
+
+        Button(
+            onClick = {
+                viewModel.save(form.toEntity()) { onDone() }
+            },
+            enabled = form.canSave,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Guardar")
+        }
+
+        if (taskId != null && existing != null) {
+            TextButton(
+                onClick = {
+                    viewModel.delete(existing) { onDone() }
+                },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("Eliminar", color = MaterialTheme.colorScheme.error)
+            }
+        }
+
+        Spacer(Modifier.height(16.dp))
+    }
+}
+
+data class MaintenanceForm(
+    val id: Long? = null,
+    val title: String = "",
+    val date: String = LocalDate.now().toString(),
+    val odometerKm: String = "",
+    val cost: String = "",
+    val materials: String = "",
+    val details: String = "",
+    val nextDate: String = "",
+    val nextOdometer: String = ""
+) {
+    val dateValid: Boolean get() = runCatching { LocalDate.parse(date) }.isSuccess
+    val odometerValid: Boolean get() = odometerKm.isBlank() || odometerKm.toDoubleOrNull() != null
+    val costValid: Boolean get() = cost.isBlank() || cost.toDoubleOrNull() != null
+    val nextDateValid: Boolean get() = nextDate.isBlank() || runCatching { LocalDate.parse(nextDate) }.isSuccess
+    val nextOdometerValid: Boolean get() = nextOdometer.isBlank() || nextOdometer.toDoubleOrNull() != null
+    val canSave: Boolean get() = title.isNotBlank() && dateValid && odometerValid && costValid && nextDateValid && nextOdometerValid
+
+    fun toEntity(): MaintenanceTask = MaintenanceTask(
+        id = id ?: 0L,
+        title = title.trim(),
+        details = details.ifBlank { null },
+        dateEpochDay = LocalDate.parse(date).toEpochDay(),
+        odometerKm = odometerKm.toDoubleOrNull(),
+        cost = cost.toDoubleOrNull(),
+        materials = materials.ifBlank { null },
+        nextDueEpochDay = nextDate.takeIf { it.isNotBlank() }?.let { LocalDate.parse(it).toEpochDay() },
+        nextDueOdometerKm = nextOdometer.toDoubleOrNull()
+    )
+
+    companion object {
+        fun from(task: MaintenanceTask): MaintenanceForm = MaintenanceForm(
+            id = task.id,
+            title = task.title,
+            date = LocalDate.ofEpochDay(task.dateEpochDay).toString(),
+            odometerKm = task.odometerKm?.toString().orEmpty(),
+            cost = task.cost?.toString().orEmpty(),
+            materials = task.materials.orEmpty(),
+            details = task.details.orEmpty(),
+            nextDate = task.nextDueEpochDay?.let { LocalDate.ofEpochDay(it).toString() }.orEmpty(),
+            nextOdometer = task.nextDueOdometerKm?.toString().orEmpty()
+        )
+    }
+}

--- a/app/src/main/java/com/joel/mycar/feature/maintenance/ui/MaintenanceListScreen.kt
+++ b/app/src/main/java/com/joel/mycar/feature/maintenance/ui/MaintenanceListScreen.kt
@@ -1,0 +1,146 @@
+package com.joel.mycar.feature.maintenance.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.joel.mycar.feature.maintenance.domain.MaintenanceTask
+import java.text.NumberFormat
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MaintenanceListScreen(
+    viewModel: MaintenanceViewModel,
+    onAdd: () -> Unit,
+    onTaskClick: (Long) -> Unit
+) {
+    val tasks by viewModel.tasks.collectAsState()
+    val currency = NumberFormat.getCurrencyInstance(Locale.getDefault())
+    val dateFormatter = rememberDateFormatter()
+
+    Scaffold(
+        floatingActionButton = {
+            FloatingActionButton(onClick = onAdd) {
+                Icon(Icons.Outlined.Add, contentDescription = "Agregar mantenimiento")
+            }
+        }
+    ) { padding ->
+        if (tasks.isEmpty()) {
+            EmptyState(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding),
+                onAdd = onAdd
+            )
+        } else {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding),
+                contentPadding = PaddingValues(16.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                items(tasks) { task ->
+                    MaintenanceTaskCard(
+                        task = task,
+                        currency = currency,
+                        dateFormatter = dateFormatter,
+                        onClick = { onTaskClick(task.id) }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun EmptyState(modifier: Modifier = Modifier, onAdd: () -> Unit) {
+    Column(
+        modifier = modifier.padding(32.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = "Aún no hay mantenimientos registrados",
+            style = MaterialTheme.typography.titleMedium
+        )
+        Text(
+            text = "Agrega tus tareas de mantenimiento para llevar un historial y recordatorios.",
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.padding(top = 8.dp)
+        )
+        Button(onClick = onAdd, modifier = Modifier.padding(top = 16.dp)) {
+            Text("Registrar mantenimiento")
+        }
+    }
+}
+
+@Composable
+private fun MaintenanceTaskCard(
+    task: MaintenanceTask,
+    currency: NumberFormat,
+    dateFormatter: DateTimeFormatter,
+    onClick: () -> Unit
+) {
+    Card(
+        onClick = onClick,
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors()
+    ) {
+        Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            Text(task.title, style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold))
+            Text("Realizado: ${dateFormatter.format(LocalDate.ofEpochDay(task.dateEpochDay))}")
+            task.odometerKm?.let { Text(String.format(Locale.US, "Odómetro: %.0f km", it)) }
+            task.cost?.let { Text("Costo: ${currency.format(it)}") }
+            task.materials?.takeIf { it.isNotBlank() }?.let {
+                Text("Materiales: $it")
+            }
+            task.details?.takeIf { it.isNotBlank() }?.let {
+                Text(it)
+            }
+            if (task.nextDueEpochDay != null || task.nextDueOdometerKm != null) {
+                Text(
+                    buildString {
+                        append("Próximo recordatorio: ")
+                        task.nextDueEpochDay?.let {
+                            append(dateFormatter.format(LocalDate.ofEpochDay(it)))
+                        }
+                        if (task.nextDueOdometerKm != null) {
+                            if (task.nextDueEpochDay != null) append(" o ")
+                            append(String.format(Locale.US, "%.0f km", task.nextDueOdometerKm))
+                        }
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun rememberDateFormatter(): DateTimeFormatter =
+    DateTimeFormatter.ofPattern("dd MMM yyyy", Locale.getDefault())

--- a/app/src/main/java/com/joel/mycar/feature/maintenance/ui/MaintenanceViewModel.kt
+++ b/app/src/main/java/com/joel/mycar/feature/maintenance/ui/MaintenanceViewModel.kt
@@ -1,0 +1,48 @@
+package com.joel.mycar.feature.maintenance.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.joel.mycar.feature.maintenance.domain.MaintenanceRepository
+import com.joel.mycar.feature.maintenance.domain.MaintenanceTask
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+class MaintenanceViewModel(
+    private val repository: MaintenanceRepository
+) : ViewModel() {
+
+    val tasks: StateFlow<List<MaintenanceTask>> = repository.tasks
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    fun taskFlow(id: Long): Flow<MaintenanceTask?> = repository.task(id)
+
+    fun save(task: MaintenanceTask, onComplete: () -> Unit = {}) {
+        viewModelScope.launch {
+            repository.save(task)
+            onComplete()
+        }
+    }
+
+    fun delete(task: MaintenanceTask, onComplete: () -> Unit = {}) {
+        viewModelScope.launch {
+            repository.delete(task)
+            onComplete()
+        }
+    }
+}
+
+class MaintenanceVMFactory(
+    private val repository: MaintenanceRepository
+) : ViewModelProvider.Factory {
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(MaintenanceViewModel::class.java)) {
+            return MaintenanceViewModel(repository) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}

--- a/app/src/main/java/com/joel/mycar/ui/HomeScreen.kt
+++ b/app/src/main/java/com/joel/mycar/ui/HomeScreen.kt
@@ -1,0 +1,59 @@
+package com.joel.mycar.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun HomeScreen(
+    toFuel: () -> Unit,
+    toMaintenance: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        verticalArrangement = Arrangement.spacedBy(24.dp, Alignment.CenterVertically),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text("MyCar", style = MaterialTheme.typography.headlineMedium)
+        Text(
+            "Elige el módulo que quieres administrar",
+            style = MaterialTheme.typography.bodyMedium
+        )
+
+        ElevatedCard(
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text("Combustible", style = MaterialTheme.typography.titleMedium)
+                Text("Registra cargas, consulta estadísticas y edita tus registros de combustible.")
+                Button(onClick = toFuel, modifier = Modifier.align(Alignment.End)) {
+                    Text("Abrir")
+                }
+            }
+        }
+
+        ElevatedCard(
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text("Mantenimiento", style = MaterialTheme.typography.titleMedium)
+                Text("Lleva un historial de tareas, costos, materiales y recordatorios de servicio.")
+                Button(onClick = toMaintenance, modifier = Modifier.align(Alignment.End)) {
+                    Text("Abrir")
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Room entity, DAO, repository, and view model to persist maintenance tasks with reminders
- implement Compose screens for maintenance list and form entry and wire them into a new home screen navigation flow
- update database schema and migrations to include maintenance data
